### PR TITLE
Nginx Web Role: Rewrite URLs to "louisville.io"

### DIFF
--- a/roles/web/files/louisville.io.conf
+++ b/roles/web/files/louisville.io.conf
@@ -1,6 +1,12 @@
 server {
+  listen 80 default_server;
+  server_name _;
+  rewrite 301 $scheme://louisville.io$request_uri;
+}
+
+server {
   listen 80;
-  server_name localhost;
+  server_name louisville.io;
   root /www/louisville.io/htdocs;
 
   gzip              on;


### PR DESCRIPTION
Added default server block which returns '301' for any hostnames not
"louisville.io". Set main server block to respond to 'louisville.io'. 
Resolves #2.