### PR TITLE
Nginx Web Configuration: correct rewrite to return

### DIFF
--- a/roles/web/files/louisville.io.conf
+++ b/roles/web/files/louisville.io.conf
@@ -1,7 +1,7 @@
 server {
   listen 80 default_server;
   server_name _;
-  rewrite 301 $scheme://louisville.io$request_uri;
+  return 301 $scheme://louisville.io$request_uri;
 }
 
 server {


### PR DESCRIPTION
Corrected improper 'rewrite' command to 'return' because author
constantly can't tell the difference. Fixes issue in #5.