### PR TITLE
Fledgling Vagrant Setup for Deploy Testing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Usage Hints:
+# 'vagrant up' will run provisioning on first boot.
+# 'vagrant provision' will run provisioning scripts without rebuilding.
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "debian/jessie64"
+
+  config.vm.network "private_network", ip: "192.168.33.10"
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = 'vagrant.yml'
+    ansible.verbose = 'vvvv'
+    ansible.sudo = true
+  end
+
+end

--- a/roles/louisville.io/tasks/main.yml
+++ b/roles/louisville.io/tasks/main.yml
@@ -1,3 +1,6 @@
+- name: Install rsync
+  apt: pkg=rsync state=installed update_cache=true
+
 - name: Download site
   git: repo=https://github.com/louisvilleio/louisville.io.git dest=/home/deploy/louisville.io
 

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -1,0 +1,10 @@
+---
+- hosts: all
+  roles:
+    - common
+    - web
+    - slackin.louisville.io
+    - louisville.io
+  remote_user: vagrant
+  vars:
+    slack_api_token: replaceme


### PR DESCRIPTION
Vagrant setup for deploy testing. Sets up Vagrant-based VM, runs slightly modified Ansible configuration. Added deterministic install of 'rsync' as we can't assume it's there (and isn't in ubuntu/jessie64).